### PR TITLE
Fix use ADMIN_DIR_NAME

### DIFF
--- a/config/cms.php
+++ b/config/cms.php
@@ -2,7 +2,7 @@
 
 return [
     'title'               => 'KodiCMS',
-    'backend_path'        => env('ADMIN_DIR_NAME', 'backend'),
+    'backend_url_segment' => env('ADMIN_DIR_NAME', 'backend'),
     'url_suffix'          => null, //'.html',
     'modules'             => [
         'API',


### PR DESCRIPTION
KodiCMS\CMS\CMS::backendUrlSegment() uses cms.backend_url_segment config key instead of cms.backend_path,
cms.backend_path seems like unused.
