### PR TITLE
Fix cms:modules:publish command

### DIFF
--- a/modules/CMS/Console/Commands/ModulePublishCommand.php
+++ b/modules/CMS/Console/Commands/ModulePublishCommand.php
@@ -21,6 +21,13 @@ class ModulePublishCommand extends VendorPublishCommand
      * @var string
      */
     protected $description = 'Publish any publishable assets from modules';
+    
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = null;
 
     /**
      * Execute the console command.

--- a/modules/CMS/Console/Commands/ModulePublishCommand.php
+++ b/modules/CMS/Console/Commands/ModulePublishCommand.php
@@ -21,7 +21,7 @@ class ModulePublishCommand extends VendorPublishCommand
      * @var string
      */
     protected $description = 'Publish any publishable assets from modules';
-    
+
     /**
      * The console command signature.
      *


### PR DESCRIPTION
The command does not work if both $signature and getOptions() are defined. So the $signature should be set to null
